### PR TITLE
getAddedIsLikedFieldToReviewsの単体テストを実装

### DIFF
--- a/__test__/functions.test.ts
+++ b/__test__/functions.test.ts
@@ -1,4 +1,9 @@
-import { getTotalPage } from '@/app/lib/functions';
+import type { Review } from '@/app/lib/definitions';
+import {
+  getAddedIsLikedFieldToReviews,
+  getTotalPage,
+} from '@/app/lib/functions';
+import type { Session } from 'next-auth';
 
 describe('getTotalPage', () => {
   test('引数がPAGE_SIZEで割り切れるとき、商を返す', () => {
@@ -18,5 +23,73 @@ describe('getTotalPage', () => {
   test('境界値: pageNumber = 0; pageNumber = 1', () => {
     expect(getTotalPage(0)).toBe(0);
     expect(getTotalPage(1)).toBe(1);
+  });
+});
+
+describe('getAddedIsLikedFieldToReviews', () => {
+  const testSession: Session = {
+    user: {
+      id: '1',
+      name: 'testName',
+      email: 'test@test.com',
+      image: 'test.com',
+    },
+    expires: '2024-11-02T12:34:56.789Z',
+  };
+  const testReview1: Review = {
+    faculty: 'Computer Science',
+    id: 1,
+    date: '2024-10-27',
+    title: 'test',
+    star: 3,
+    createdBy: 'test',
+    className: 'test',
+    isAnonymous: false,
+    evaluation: 'test',
+    universityId: 1,
+    user: {
+      name: 'test',
+      image: 'test.com',
+    },
+  };
+  const testReview2: Review = {
+    faculty: 'Computer Science',
+    id: 2,
+    date: '2024-10-28',
+    title: 'test',
+    star: 3,
+    createdBy: 'test2',
+    className: 'test',
+    isAnonymous: false,
+    evaluation: 'test',
+    universityId: 1,
+    user: {
+      name: 'test2',
+      image: 'test.com',
+    },
+  };
+  test('Reviewの配列を渡すとフィールドにisLiked: trueのReviewWithLikes[]が返ってくる', () => {
+    const testReview: Review[] = [testReview1, testReview2];
+    expect(getAddedIsLikedFieldToReviews(testReview, testSession)).toEqual([
+      { ...testReview1, isLiked: false },
+      { ...testReview2, isLiked: false },
+    ]);
+  });
+  test('Reviewにいいねしたセッションを渡すとフィールドにisLiked: trueのReviewWithLikes[]が返ってくる', () => {
+    // testReview1にlikesフィールドを追加してtestSessionのデータを挿入
+    const addLikesField = {
+      ...testReview1,
+      likes: [{ id: 1, reviewId: 1, userId: '1' }],
+    };
+    const testReview: Review[] = [addLikesField];
+
+    expect(getAddedIsLikedFieldToReviews(testReview, testSession)).toEqual([
+      { ...addLikesField, isLiked: true },
+    ]);
+  });
+  test('sessionがnullの場合フィールドにisLiked: falseのReviewWithLikes[]が返ってくる', () => {
+    expect(getAddedIsLikedFieldToReviews([testReview1], null)).toEqual([
+      { ...testReview1, isLiked: false },
+    ]);
   });
 });

--- a/src/app/lib/definitions.ts
+++ b/src/app/lib/definitions.ts
@@ -11,7 +11,6 @@ export type Review = {
   universityId: number;
   user: User;
   likes?: Likes[];
-  // isLiked?: boolean;
 };
 
 export type ReviewWithLike = Review & {

--- a/src/app/lib/functions.ts
+++ b/src/app/lib/functions.ts
@@ -4,7 +4,11 @@ import {
   DEFAULT_PAGE,
   PAGE_SIZE,
 } from '@/app/lib/constants';
-import type { Review, searchParmas } from '@/app/lib/definitions';
+import type {
+  Review,
+  ReviewWithLike,
+  searchParmas,
+} from '@/app/lib/definitions';
 import type { Session } from 'next-auth';
 
 export function getTotalPage(pageCount: number) {
@@ -28,7 +32,7 @@ export function getQueryParams(searchParams?: searchParmas) {
 export function getAddedIsLikedFieldToReviews(
   reviews: Review[],
   session: Session | null,
-) {
+): ReviewWithLike[] {
   const reviewsAddedIsLiked = reviews.map((review) => {
     // レビューをいいねした人の中にsession?.user?.idがあったらtrueを返す
     // booleanがわかればいいのでmapではなくsomeを使用


### PR DESCRIPTION
### 変更内容
- `__test__/functions.test.ts`

   - `getAddedIsLikedFieldToReviews`の単体テストを実装
- `src/app/lib/functions.ts`

   - `getAddedIsLikedFieldToReviews`の戻り値に`型ReviewWithLike[]`を適用
  


- `src/app/lib/definitions.ts`

    -  コメントアウトされていた、`isLiked?: boolean;`を削除

### テストケース
- 正常なReviewとsessionを渡し、フィールドにisLikedが追加されるかを確認
- 正常なReviewとReviewをいいねしたユーザのsessionを渡し、フィールドにisLiked: trueが追加されるか確認
- 正常なReviewとsessionをnullしたデータを渡した時、フィールドがisLiked: falseが追加される確認

### 実行方法
- `npx jest -t getAddedIsLikedFieldToReviews`で実行可能
