### PR TITLE
getQueryParamsのテストを実装

### DIFF
--- a/__test__/functions.test.ts
+++ b/__test__/functions.test.ts
@@ -1,6 +1,12 @@
+import {
+  DEFAULT_CLASS_NAME,
+  DEFAULT_FACULTY_NAME,
+  DEFAULT_SORT,
+} from '@/app/lib/constants';
 import type { Review } from '@/app/lib/definitions';
 import {
   getAddedIsLikedFieldToReviews,
+  getQueryParams,
   getTotalPage,
 } from '@/app/lib/functions';
 import type { Session } from 'next-auth';
@@ -91,5 +97,33 @@ describe('getAddedIsLikedFieldToReviews', () => {
     expect(getAddedIsLikedFieldToReviews([testReview1], null)).toEqual([
       { ...testReview1, isLiked: false },
     ]);
+  });
+});
+
+describe('getQueryParams', () => {
+  test('searchParmasを渡して、それぞれのパラメータが返ってくる', () => {
+    const searchParams = {
+      classname: 'test',
+      page: '1',
+      sort: 'asc' as const,
+      faculty: 'Computer Science',
+    };
+
+    expect(getQueryParams(searchParams)).toEqual({
+      className: 'test',
+      currentPage: 1,
+      sort: 'asc',
+      faculty: 'Computer Science',
+    });
+  });
+  test('パラメータがないsearchParmasを渡した時、デフォルトのパラメータが返ってくる', () => {
+    const searchParams = { page: '1' };
+
+    expect(getQueryParams(searchParams)).toEqual({
+      className: DEFAULT_CLASS_NAME,
+      currentPage: 1,
+      sort: DEFAULT_SORT,
+      faculty: DEFAULT_FACULTY_NAME,
+    });
   });
 });

--- a/src/app/lib/constants.ts
+++ b/src/app/lib/constants.ts
@@ -4,3 +4,4 @@ export const DEFAULT_UNIVERSITY_NAME = '';
 export const DEFAULT_CLASS_NAME = '';
 export const DEFAULT_FACULTY_NAME = '';
 export const DEFAULT_NAME = '名前未設定';
+export const DEFAULT_SORT = 'desc';

--- a/src/app/lib/functions.ts
+++ b/src/app/lib/functions.ts
@@ -1,7 +1,7 @@
 import {
   DEFAULT_CLASS_NAME,
   DEFAULT_FACULTY_NAME,
-  DEFAULT_PAGE,
+  DEFAULT_SORT,
   PAGE_SIZE,
 } from '@/app/lib/constants';
 import type {
@@ -19,12 +19,12 @@ export function getTotalPage(pageCount: number) {
     : Math.floor(pageCount / PAGE_SIZE) + 1;
 }
 
-export function getQueryParams(searchParams?: searchParmas) {
+export function getQueryParams(searchParams: searchParmas) {
   // QueryParamsを取得
-  const className = searchParams?.classname || DEFAULT_CLASS_NAME;
-  const currentPage = Number(searchParams?.page) || DEFAULT_PAGE;
-  const sort = searchParams?.sort || 'desc'; // デフォルトで降順にソート
-  const faculty = searchParams?.faculty || DEFAULT_FACULTY_NAME;
+  const className = searchParams.classname || DEFAULT_CLASS_NAME;
+  const currentPage = Number(searchParams.page);
+  const sort = searchParams.sort || DEFAULT_SORT;
+  const faculty = searchParams.faculty || DEFAULT_FACULTY_NAME;
 
   return { className, currentPage, sort, faculty };
 }


### PR DESCRIPTION
### 変更内容
- `__test__/functions.test.ts`
    - `getQueryParams`の単体テストを実装
   
- `src/app/lib/functions.ts`
    - `getQueryParams`において、`searchParams.sort`がなかった場合`DEFAULT_SORT`をsortに代入

- 'src/app/lib/constants.ts`
    - デフォルトのソート値`DEFAULT_SORT`を追加 

### `getQueryParams`のテストケース
- パラメータが全て揃ったsearchParamsを渡し、正しいパラメータが返ってくるか確認
- パラメータがpageのみのserachPramsを渡し、値がないパラメータについてはデフォルト値が返ってくるか確認

### テスト実行方法
```typescript
npx jest -t getQueryParams